### PR TITLE
Use external IDAM URLs and included old upload scripts for backup

### DIFF
--- a/definition/bin/deprecated/ccd/add-ccd-role.sh
+++ b/definition/bin/deprecated/ccd/add-ccd-role.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+## Add user role in ccd
+##
+## Usage: ./add-ccd-role.sh role [classification] [userToken] [env]
+##
+## Options:
+##    - role: Name of the role. Must be an existing IDAM role.
+##    - classification: Classification granted to the role; one of `PUBLIC`,
+##        `PRIVATE` or `RESTRICTED`. Default to `PUBLIC`.
+##
+## Add support for an IDAM role in CCD.
+
+role=$1
+classification=$2
+userToken=$3
+env=$4
+
+if [ -z "$role" ]
+  then
+    echo "Usage: ./add-ccd-role.sh role [classification] [userToken] [env]"
+    exit 1
+fi
+
+case $classification in
+  PUBLIC|PRIVATE|RESTRICTED)
+    ;;
+  *)
+    echo "Classification must be one of: PUBLIC, PRIVATE or RESTRICTED"
+    exit 1 ;;
+esac
+
+curl -k ${CURL_OPTS} -XPUT \
+  https://ccd-api-gateway-web-${env}.service.core-compute-${env}.internal/definition_import/api/user-role \
+  -H "Authorization: Bearer ${userToken}" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"'${role}'","security_classification":"'${classification}'"}'

--- a/definition/bin/deprecated/ccd/idam-authenticate.sh
+++ b/definition/bin/deprecated/ccd/idam-authenticate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+IMPORTER_USERNAME=$1
+IMPORTER_PASSWORD=$2
+IDAM_URI=$3
+REDIRECT_URI=$4
+CLIENT_SECRET=$5
+
+code=$(curl ${CURL_OPTS} -u "${IMPORTER_USERNAME}:${IMPORTER_PASSWORD}" -XPOST "${IDAM_URI}/oauth2/authorize?redirect_uri=${REDIRECT_URI}&response_type=code&client_id=cmc_citizen" -d ""| jq -r .code)
+
+curl ${CURL_OPTS} -H "Content-Type: application/x-www-form-urlencoded" -u "cmc_citizen:${CLIENT_SECRET}" -XPOST "${IDAM_URI}/oauth2/token?code=${code}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" -d ""| jq -r .access_token

--- a/definition/bin/deprecated/ccd/import-definition.sh
+++ b/definition/bin/deprecated/ccd/import-definition.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+## Import the given definition in CCD definition store.
+##
+## Usage: ./import-definition.sh path_to_definition [userToken] [env]
+##
+## Prerequisites:
+##  - Microservice `ccd_gw` must be authorised to call service `ccd-definition-store-api`
+
+if [ -z "$1" ]
+  then
+    echo "Usage: ./import-definition.sh path_to_definition [userToken] [env]"
+    exit 1
+elif [ ! -f "$1" ]
+  then
+    echo "File not found: $1"
+    exit 1
+fi
+
+userToken=$2
+env=$3
+
+curl -vvv -k ${CURL_OPTS} \
+  https://ccd-api-gateway-web-${env}.service.core-compute-${env}.internal/definition_import/import \
+  -H "Authorization: Bearer ${userToken}" \
+  -F file="@$1"

--- a/definition/bin/deprecated/upload-ccd-definition-to-env.sh
+++ b/definition/bin/deprecated/upload-ccd-definition-to-env.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+if [[ ${1} = "-v" ]]; then
+  export CURL_OPTS='-v'
+  shift
+else
+  export CURL_OPTS='--fail --silent'
+fi
+
+if [ -z "${1}" ]
+  then
+    echo "Usage: ./upload-definition.sh [env]\n${ENV_MESSAGE}"
+    exit 1
+fi
+
+env=${1}
+
+case ${env} in
+  saat)
+    IDAM_URI="http://idam-api-idam-saat.service.core-compute-idam-saat.internal"
+    IDAM_ENV="test"
+  ;;
+  sprod)
+    IDAM_URI="http://idam-api-idam-sprod.service.core-compute-idam-sprod.internal"
+    IDAM_ENV="test"
+  ;;
+  aat)
+    IDAM_URI="https://idam-api.aat.platform.hmcts.net"
+    IDAM_ENV="preprod"
+  ;;
+  demo)
+    IDAM_URI="https://idam-api.demo.platform.hmcts.net"
+    IDAM_ENV="demo"
+  ;;
+  prod)
+    IDAM_URI="https://prod-idamapi.reform.hmcts.net:3511"
+    IDAM_ENV="prod"
+  ;;
+  *)
+    echo ${ENV_MESSAGE}
+    exit 1 ;;
+esac
+
+export CLAIM_STORE_BASE_URL=http://cmc-claim-store-${env}.service.core-compute-${env}.internal
+
+function keyVaultRead() {
+  az keyvault secret show --vault-name cmc-vault --name ${1} --query value -o tsv
+}
+
+echo "Reading importer credentials from vault for idam env: ${IDAM_ENV}"
+
+az account show &> /dev/null || {
+    echo "Please run \`az login\` and follow the instructions first"
+    exit 1
+}
+
+IMPORTER_USERNAME=civilmoneyclaims+definition@gmail.com #$(keyVaultRead "ccd-importer-username-${IDAM_ENV}")
+IMPORTER_PASSWORD=Yv607HRsg #$(keyVaultRead "ccd-importer-password-${IDAM_ENV}")
+CLIENT_SECRET=$(keyVaultRead "oauth-client-secret-${IDAM_ENV}")
+REDIRECT_URI=$(keyVaultRead "oauth-redirect-uri-${IDAM_ENV}")
+
+proxy=http://proxyout.reform.hmcts.net:8080
+export http_proxy=${proxy}
+export https_proxy=${proxy}
+
+echo "Authenticating to idam"
+userToken=$(ccd/idam-authenticate.sh ${IMPORTER_USERNAME} ${IMPORTER_PASSWORD} ${IDAM_URI} ${REDIRECT_URI} ${CLIENT_SECRET})
+
+echo "Adding CMC required roles to CCD"
+
+# add ccd role
+ccd/add-ccd-role.sh "caseworker-cmc" "RESTRICTED" "${userToken}" "${env}"
+ccd/add-ccd-role.sh "caseworker-cmc-solicitor" "RESTRICTED" "${userToken}" "${env}"
+ccd/add-ccd-role.sh "citizen" "PUBLIC" "${userToken}" "${env}"
+ccd/add-ccd-role.sh "letter-holder" "PUBLIC" "${userToken}" "${env}"
+ccd/add-ccd-role.sh "caseworker-cmc-systemupdate" "RESTRICTED" "${userToken}" "${env}"
+
+echo "Uploading CMC definition to CCD"
+# upload definition file
+ccd/import-definition.sh "cmc-ccd-v1.2.5_AAT.xlsx" "${userToken}" "${env}"
+
+# Add blank line to end
+echo

--- a/definition/bin/upload-ccd-definition-to-env.sh
+++ b/definition/bin/upload-ccd-definition-to-env.sh
@@ -60,18 +60,21 @@ case ${ENV} in
     CLAIM_STORE_URL=http://claim-store:4400 # docker-compose service
   ;;
   saat|sprod)
+    # INTERNAL IDAM URLS NOT WORK AS EXPECTED!!!
     IMPORTER_USERNAME=$(keyVaultRead "ccd-importer-username-test")
     IMPORTER_PASSWORD=$(keyVaultRead "ccd-importer-password-test")
     CLIENT_SECRET=$(keyVaultRead "ccd-importer-client-secret-test")
     REDIRECT_URI=$(keyVaultRead "ccd-importer-redirect-uri-test")
   ;;
   aat)
+    IDAM_URI=https://idam-api.aat.platform.hmcts.net
     IMPORTER_USERNAME=$(keyVaultRead "ccd-importer-username-preprod")
     IMPORTER_PASSWORD=$(keyVaultRead "ccd-importer-password-preprod")
     CLIENT_SECRET=$(keyVaultRead "ccd-importer-client-secret-preprod")
     REDIRECT_URI=$(keyVaultRead "ccd-importer-redirect-uri-preprod")
   ;;
   demo)
+    IDAM_URI=https://idam-api.demo.platform.hmcts.net
     IMPORTER_USERNAME=$(keyVaultRead "ccd-importer-username-demo")
     IMPORTER_PASSWORD=$(keyVaultRead "ccd-importer-password-demo")
     CLIENT_SECRET=$(keyVaultRead "ccd-importer-client-secret-demo")


### PR DESCRIPTION

### Change description ###

Fixed current upload scripts to use external IDAM URLs - not working with internal for some reason! 🤔 

Also copied old upload scripts from integration-tests repo pre-merge, had to change slightly with script paths and logging. 

**Does this PR introduce a breaking change?**

```
- [ ] Yes
- [x] No
```
