### PR TITLE
Added PAPER_RESPONSE_COUNTER_CLAIM StaffDocumentType (demo change)

### DIFF
--- a/definition/data/sheets/FixedLists.json
+++ b/definition/data/sheets/FixedLists.json
@@ -133,6 +133,7 @@
   {"ID": "StaffDocumentType", "ListElementCode": "PAPER_RESPONSE_STATES_PAID", "ListElement": "Paper response-States paid"},
   {"ID": "StaffDocumentType", "ListElementCode": "PAPER_RESPONSE_MORE_TIME", "ListElement": "Paper response-More time request"},
   {"ID": "StaffDocumentType", "ListElementCode": "PAPER_RESPONSE_DISPUTES_ALL", "ListElement": "Paper response-Disputes all"},
+  {"ID": "StaffDocumentType", "ListElementCode": "PAPER_RESPONSE_COUNTER_CLAIM", "ListElement": "Paper response-Counter claim"},
   {"ID": "StaffDocumentType", "ListElementCode": "OTHER", "ListElement": "Other"},
   {"ID": "ScannedDocumentType", "ListElementCode": "cherished", "ListElement": "Cherished"},
   {"ID": "ScannedDocumentType", "ListElementCode": "other", "ListElement": "Other"},


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/ROC-7859 ###

### Change description ###

Added PAPER_RESPONSE_COUNTER_CLAIM StaffDocumentType

**Does this PR introduce a breaking change?**

```
- [X] Yes - Can only be merged after https://github.com/hmcts/cmc-claim-store/pull/1661
- [ ] No
```
