### PR TITLE
CIV-2648: Hide create results from CMC caseworkers

### DIFF
--- a/definition/data/sheets/AuthorisationCaseState.json
+++ b/definition/data/sheets/AuthorisationCaseState.json
@@ -1,5 +1,4 @@
 [
-  {"CaseTypeID": "MoneyClaimCase", "CaseStateID": "create", "UserRole": "caseworker-cmc", "CRUD": "CRUD"},
   {"CaseTypeID": "MoneyClaimCase", "CaseStateID": "open", "UserRole": "caseworker-cmc", "CRUD": "CRUD"},
   {"CaseTypeID": "MoneyClaimCase", "CaseStateID": "closed", "UserRole": "caseworker-cmc", "CRUD": "CRUD"},
   {"CaseTypeID": "MoneyClaimCase", "CaseStateID": "settled", "UserRole": "caseworker-cmc", "CRUD": "CRUD"},


### PR DESCRIPTION
**Confirm that:**

- [ ] *VERSION* has been bumped (only for definition file changes)
- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-2648

### Change description ###

Hides create results from CMC caseworkers. These results are still available to other types of caseworkers however.

**Does this PR introduce a breaking change?**

```
- [ ] Yes
- [ ] No
```
