### PR TITLE
skip importing definitions in preview and deleting resource folder after

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -66,6 +66,7 @@ withPipeline("nodejs", product, component) {
 
   afterAlways('functionalTest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
+    yarnBuilder.yarn('empty-resources-dir')
     env.ENVIRONMENT="prod"
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -57,7 +57,9 @@ withPipeline("nodejs", product, component) {
     stageWithAgent('Generate CMC CCD domain and definition config', product) {
       env.CCD_DEF_CLAIM_STORE_BASE_URL = "http://cmc-claim-store-${env.ENVIRONMENT}.service.core-compute-${env.ENVIRONMENT}.internal"
       yarnBuilder.yarn('generate-excel')
-      yarnBuilder.yarn('copy-excel-to-resources')
+      if(env.ENVIRONMENT == 'preview') {
+        yarnBuilder.yarn('copy-excel-to-resources')
+      }
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'definition/xlsx/*.xlsx'
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -57,7 +57,7 @@ withPipeline("nodejs", product, component) {
     stageWithAgent('Generate CMC CCD domain and definition config', product) {
       env.CCD_DEF_CLAIM_STORE_BASE_URL = "http://cmc-claim-store-${env.ENVIRONMENT}.service.core-compute-${env.ENVIRONMENT}.internal"
       yarnBuilder.yarn('generate-excel')
-      if(env.ENVIRONMENT == 'preview') {
+      if(env.ENVIRONMENT != 'preview') {
         yarnBuilder.yarn('copy-excel-to-resources')
       }
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'definition/xlsx/*.xlsx'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node index.js",
     "generate-excel": "./bin/pull-definition-from-docker.sh ${ENVIRONMENT:-local}",
     "copy-excel-to-resources": "cp -R definition/xlsx/cmc-ccd-${ENVIRONMENT:-local}.xlsx src/test/resources/ccd_definition",
+    "empty-resources-dir": "rm src/test/resources/ccd_definition/*.xlsx",
     "lint": "echo lint",
     "test": "echo test",
     "test:a11y": "echo test:a11y",

--- a/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
+++ b/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
@@ -24,6 +24,7 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
     protected void doLoadTestData() {
         List<String> definitionFileResources = getAllDefinitionFilesToLoadAt(definitionsPath);
         CcdEnvironment currentEnv = (CcdEnvironment) getDataSetupEnvironment();
+        System.out.println("current environment:  " + currentEnv);
         try {
             if (currentEnv != null && !SKIPPED_ENVS.contains(currentEnv)) {
                 importDefinitions();

--- a/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
+++ b/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
@@ -3,11 +3,14 @@ package uk.gov.hmcts.cmc;
 import uk.gov.hmcts.befta.dse.ccd.CcdEnvironment;
 import uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
 
     private static final String definitionsPath = "ccd_definition";
+    private static final List<CcdEnvironment> SKIPPED_ENVS = Arrays.asList(
+        CcdEnvironment.PREVIEW);
 
     public HighLevelDataSetupApp(CcdEnvironment dataSetupEnvironment) {
         super(dataSetupEnvironment, definitionsPath);
@@ -22,7 +25,7 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
         List<String> definitionFileResources = getAllDefinitionFilesToLoadAt(definitionsPath);
         CcdEnvironment currentEnv = (CcdEnvironment) getDataSetupEnvironment();
         try {
-            if (currentEnv != null) {
+            if (currentEnv != null && !SKIPPED_ENVS.contains(currentEnv)) {
                 importDefinitions();
             } else {
                 definitionFileResources.forEach(file ->

--- a/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
+++ b/src/test/java/uk/gov/hmcts/cmc/HighLevelDataSetupApp.java
@@ -3,14 +3,11 @@ package uk.gov.hmcts.cmc;
 import uk.gov.hmcts.befta.dse.ccd.CcdEnvironment;
 import uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
 
     private static final String definitionsPath = "ccd_definition";
-    private static final List<CcdEnvironment> SKIPPED_ENVS = Arrays.asList(
-        CcdEnvironment.PREVIEW);
 
     public HighLevelDataSetupApp(CcdEnvironment dataSetupEnvironment) {
         super(dataSetupEnvironment, definitionsPath);
@@ -24,9 +21,8 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
     protected void doLoadTestData() {
         List<String> definitionFileResources = getAllDefinitionFilesToLoadAt(definitionsPath);
         CcdEnvironment currentEnv = (CcdEnvironment) getDataSetupEnvironment();
-        System.out.println("current environment:  " + currentEnv);
         try {
-            if (currentEnv != null && !SKIPPED_ENVS.contains(currentEnv)) {
+            if (currentEnv != null) {
                 importDefinitions();
             } else {
                 definitionFileResources.forEach(file ->


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-33


### Change description ###
For some reason, the environment is set to AAT in preview. skipping the copy function so nothing gets uploaded to preview.
probably because of this
https://github.com/hmcts/cnp-jenkins-library/blob/ec3b2f4af0e9836e51b485a924920c0229c90ec3/README.md?plain=1#L230

Also delete resource folder after as aat config also gets uploaded in prod.

**Does this PR introduce a breaking change?**

```
- [ ] Yes
- [X] No
```
